### PR TITLE
Update ghostwriter/coding-standard to version dev-main#62def0c

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,19 +38,19 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.1.0",
-        "ghostwriter/container": "^5.0.1",
-        "ghostwriter/event-dispatcher": "^5.0.3",
-        "ghostwriter/filesystem": "^0.1.1",
-        "nikic/php-parser": "^5.6.1",
-        "sebastian/diff": "^7.0.0"
+        "ghostwriter/case-converter": "~2.1.0",
+        "ghostwriter/container": "~5.0.1",
+        "ghostwriter/event-dispatcher": "~5.0.3",
+        "ghostwriter/filesystem": "~0.1.1",
+        "nikic/php-parser": "~5.6.1",
+        "sebastian/diff": "~7.0.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5d915585007acbd2d0caf76700996c2",
+    "content-hash": "eed6ed8e033bc48e88cdf5b6b0f6ad3f",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1073,12 +1073,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
-                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
                 "shasum": ""
             },
             "require": {
@@ -1235,7 +1235,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T13:20:26+00:00"
+            "time": "2025-09-21T14:31:25+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#4c9bc3e` to `dev-main#62def0c`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`