### PR TITLE
Update ghostwriter/coding-standard to version dev-main#304b3fc

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1014,12 +1014,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "eb4a5f0d8fc4c82c89fc26c83e4883979f0eadad"
+                "reference": "304b3fc8b0e3937a3987aa068e52760d79c94c11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/eb4a5f0d8fc4c82c89fc26c83e4883979f0eadad",
-                "reference": "eb4a5f0d8fc4c82c89fc26c83e4883979f0eadad",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/304b3fc8b0e3937a3987aa068e52760d79c94c11",
+                "reference": "304b3fc8b0e3937a3987aa068e52760d79c94c11",
                 "shasum": ""
             },
             "require": {
@@ -1165,7 +1165,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-02T01:14:37+00:00"
+            "time": "2025-11-02T03:40:48+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#eb4a5f0` to `dev-main#304b3fc`.

This pull request changes the following file(s): 

- Update `composer.lock`