### PR TITLE
Update `boundwize/structarmed` to version `0.14.18`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.14.16",
+        "boundwize/structarmed": "^0.14.18",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "787a4daaa78ea94409e59df4c04ccc57",
+    "content-hash": "4b39d0d901b7b908807456df524bb0ac",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -655,16 +655,16 @@
         },
         {
             "name": "boundwize/structarmed",
-            "version": "0.14.16",
+            "version": "0.14.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "7e5a00e00f13211d6c9efa8ad4d8895ba9fa640b"
+                "reference": "2f7c0329feeb23a49a1f80a0253a2bc3d546f4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7e5a00e00f13211d6c9efa8ad4d8895ba9fa640b",
-                "reference": "7e5a00e00f13211d6c9efa8ad4d8895ba9fa640b",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/2f7c0329feeb23a49a1f80a0253a2bc3d546f4d8",
+                "reference": "2f7c0329feeb23a49a1f80a0253a2bc3d546f4d8",
                 "shasum": ""
             },
             "require": {
@@ -675,7 +675,7 @@
                 "php": "^8.2"
             },
             "require-dev": {
-                "boundwize/pyrameter": "^0.3",
+                "boundwize/pyrameter": "^0.5",
                 "laminas/laminas-coding-standard": "^3.1",
                 "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^11.5",
@@ -720,7 +720,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.14.16"
+                "source": "https://github.com/boundwize/structarmed/tree/0.14.18"
             },
             "funding": [
                 {
@@ -728,7 +728,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-14T12:41:44+00:00"
+            "time": "2026-07-18T11:49:21+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.14.16` to `0.14.18`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`