### PR TITLE
Update `boundwize/jsonrecast` to version `0.3.25`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -586,16 +586,16 @@
     "packages-dev": [
         {
             "name": "boundwize/jsonrecast",
-            "version": "0.3.24",
+            "version": "0.3.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/jsonrecast.git",
-                "reference": "64d8efc75b723b567c7cac1ed4905aec10ba3645"
+                "reference": "795dc5358ab3f1d3404066c902bd226608f30cd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/jsonrecast/zipball/64d8efc75b723b567c7cac1ed4905aec10ba3645",
-                "reference": "64d8efc75b723b567c7cac1ed4905aec10ba3645",
+                "url": "https://api.github.com/repos/boundwize/jsonrecast/zipball/795dc5358ab3f1d3404066c902bd226608f30cd6",
+                "reference": "795dc5358ab3f1d3404066c902bd226608f30cd6",
                 "shasum": ""
             },
             "require": {
@@ -643,7 +643,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/jsonrecast/issues",
-                "source": "https://github.com/boundwize/jsonrecast/tree/0.3.24"
+                "source": "https://github.com/boundwize/jsonrecast/tree/0.3.25"
             },
             "funding": [
                 {
@@ -651,7 +651,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-16T04:55:18+00:00"
+            "time": "2026-07-18T03:51:45+00:00"
         },
         {
             "name": "boundwize/structarmed",


### PR DESCRIPTION
Updates the [`boundwize/jsonrecast`](https://packagist.org/packages/boundwize/jsonrecast) dependency from `0.3.24` to `0.3.25`.

This pull request changes the following file(s): 

- Update `composer.lock`